### PR TITLE
fix: add missing parentheses to function calls

### DIFF
--- a/lib/ex_unit_fixtures/imp/module_store.ex
+++ b/lib/ex_unit_fixtures/imp/module_store.ex
@@ -15,7 +15,7 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   """
   @spec register(atom, String.t) :: :ok
   def register(module, file) do
-    check_server_running
+    check_server_running()
 
     Agent.update __MODULE__, fn modules ->
       [{module, file} | modules]
@@ -27,7 +27,7 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   """
   @spec find_file(String.t) :: [:atom]
   def find_file(filename) do
-    check_server_running
+    check_server_running()
 
     filename = Path.absname(filename)
     Agent.get __MODULE__, fn state ->
@@ -40,7 +40,7 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
   """
   @spec find_module(:atom) :: String.t
   def find_module(search_module) do
-    check_server_running
+    check_server_running()
 
     __MODULE__
     |> Agent.get(fn state ->
@@ -49,7 +49,7 @@ defmodule ExUnitFixtures.Imp.ModuleStore do
     |> List.first
   end
 
-  @spec check_server_running :: nil | no_return
+  @spec check_server_running() :: nil | no_return
   defp check_server_running do
     if Process.whereis(__MODULE__) == nil do
       raise """

--- a/lib/ex_unit_fixtures/teardown.ex
+++ b/lib/ex_unit_fixtures/teardown.ex
@@ -23,7 +23,7 @@ defmodule ExUnitFixtures.Teardown do
   """
   @spec register_pid(reference) :: :ok
   def register_pid(module_ref) when is_reference(module_ref) do
-    register_pid(module_ref, self)
+    register_pid(module_ref, self())
   end
 
   @doc """
@@ -54,7 +54,7 @@ defmodule ExUnitFixtures.Teardown do
   end
 
   def register_teardown(:module, fun) when is_function(fun, 0) do
-    pid = self
+    pid = self()
     Agent.update(__MODULE__, fn (state = %{teardowns: tds, pids: pids}) ->
       unless Map.has_key?(pids, pid) do
         raise "register_teardown/2 can only be invoked from the test process"


### PR DESCRIPTION
Add parentheses to check_server_running and self function calls and spec for elixir 1.18 compatibility.